### PR TITLE
🐛 Include api group on command line

### DIFF
--- a/scripts/kubectl-kubestellar-ensure-location
+++ b/scripts/kubectl-kubestellar-ensure-location
@@ -112,7 +112,7 @@ if [ "$imw" != "." ]
 then kubectl ws "${kubectl_flags[@]}" "$imw"
 fi
 
-if ! kubectl "${kubectl_flags[@]}" get SyncTarget "$objname" &> /dev/null; then
+if ! kubectl "${kubectl_flags[@]}" get synctargets.edge.kcp.io "$objname" &> /dev/null; then
 (cat <<EOF
 apiVersion: edge.kcp.io/v1alpha1
 kind: SyncTarget
@@ -127,7 +127,7 @@ EOF
 }
 fi
 
-if ! kubectl "${kubectl_flags[@]}" get Location "$objname" &> /dev/null; then
+if ! kubectl "${kubectl_flags[@]}" get locations.edge.kcp.io "$objname" &> /dev/null; then
 (cat <<EOF
 apiVersion: edge.kcp.io/v1alpha1
 kind: Location
@@ -144,13 +144,13 @@ EOF
 }
 fi
 
-if kubectl "${kubectl_flags[@]}" get Location default &> /dev/null; then
-    kubectl "${kubectl_flags[@]}" delete Location default &> /dev/null
+if kubectl "${kubectl_flags[@]}" get locations.edge.kcp.io default &> /dev/null; then
+    kubectl "${kubectl_flags[@]}" delete locations.edge.kcp.io default &> /dev/null
 fi
 
 
-stlabs=$(kubectl "${kubectl_flags[@]}" get SyncTarget "$objname" -o json | jq .metadata.labels)
-loclabs=$(kubectl "${kubectl_flags[@]}" get Location "$objname" -o json | jq .metadata.labels)
+stlabs=$(kubectl "${kubectl_flags[@]}" get synctargets.edge.kcp.io "$objname" -o json | jq .metadata.labels)
+loclabs=$(kubectl "${kubectl_flags[@]}" get locations.edge.kcp.io "$objname" -o json | jq .metadata.labels)
 
 let index=0 1
 while (( index < ${#labels[*]} )); do
@@ -159,14 +159,14 @@ while (( index < ${#labels[*]} )); do
     let index=index+2
     stval=$(jq -r <<<"$stlabs" ".[\"${key}\"]")
     if [ "$stval" != "$val" ]; then
-	if ! kubectl "${kubectl_flags[@]}" label --overwrite SyncTarget "$objname" "${key}=${val}" ; then
+	if ! kubectl "${kubectl_flags[@]}" label --overwrite synctargets.edge.kcp.io "$objname" "${key}=${val}" ; then
 	    echo "$0: failed to add label to SyncTarget" >&2
 	    exit 4
 	fi
     fi
     locval=$(jq -r <<<"$loclabs" ".[\"${key}\"]")
     if [ "$locval" != "$val" ]; then
-	if ! kubectl "${kubectl_flags[@]}" label --overwrite Location "$objname" "${key}=${val}" ; then
+	if ! kubectl "${kubectl_flags[@]}" label --overwrite locations.edge.kcp.io "$objname" "${key}=${val}" ; then
 	    echo "$0: failed to add label to Location" >&2
 	    exit 4
 	fi


### PR DESCRIPTION
To avoid confusion in kcp workspaces (which have APIBindings to TMC in kcp v0.11.0).

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the ensure-location script to specify the API group on the command line.  This avoids ambiguity when run against a kcp workspace that has APIBindings to TMC.

## Related issue(s)

Fixes #
